### PR TITLE
reactGroup changes: added retire, remove delete, added memberStatistic

### DIFF
--- a/backend/src/main/java/ru/itmo/backend/controllers/ReactGroupController.java
+++ b/backend/src/main/java/ru/itmo/backend/controllers/ReactGroupController.java
@@ -11,6 +11,7 @@ import ru.itmo.backend.models.*;
 import ru.itmo.backend.service.CardService;
 import ru.itmo.backend.service.GroupResourceService;
 import ru.itmo.backend.service.ReactGroupService;
+import ru.itmo.backend.service.StatisticService;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -22,26 +23,41 @@ public class ReactGroupController {
     private final ReactGroupService reactGroupService;
     private final CardService cardService;
     private final GroupResourceService groupResourceService;
+    private final StatisticService statisticService;
 
     @Autowired
     public ReactGroupController(ReactGroupService reactGroupService
                                 , CardService cardService
-                                , GroupResourceService groupResourceService) {
+                                , GroupResourceService groupResourceService
+                                , StatisticService statisticService) {
         this.reactGroupService = reactGroupService;
         this.cardService = cardService;
         this.groupResourceService = groupResourceService;
+        this.statisticService = statisticService;
     }
 
-    @GetMapping
+    @GetMapping("/all")
     public ResponseEntity<List<ReactGroup>> getAllGroups(){
         List<ReactGroup> reactGroups = reactGroupService.getAllMembers();
         return new ResponseEntity<>(reactGroups, HttpStatus.OK);
+    }
+
+    @GetMapping("/allworking")
+    public ResponseEntity<List<ReactGroup>> getAllWorkingGroup(){
+        List<ReactGroup> workingReactGroup = reactGroupService.getAllWorkingMembers();
+        return new ResponseEntity<>(workingReactGroup, HttpStatus.OK);
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<ReactGroup> getReactGroup(@PathVariable Long id){
         ReactGroup reactGroup = reactGroupService.findGroupMemberById(id);
         return new ResponseEntity<>(reactGroup, HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}/statistic")
+    public ResponseEntity<ReactGroupStatisticDto> getMemberStatistic(@PathVariable Long id){
+        ReactGroupStatisticDto reactGroupStatisticDto = statisticService.getGroupMemberStatistic(id);
+        return new ResponseEntity<>(reactGroupStatisticDto, HttpStatus.OK);
     }
 
     @GetMapping("/criminal")
@@ -105,8 +121,8 @@ public class ReactGroupController {
     }
 
     @PostMapping("/newman")
-    public ResponseEntity<ReactGroupDto> addNewMan(@Valid @RequestBody ReactGroupDto reactGroupDto){
-        ReactGroupDto newGroupMember = reactGroupService.createNewGroupMember(reactGroupDto);
+    public ResponseEntity<ReactGroupOutDto> addNewMan(@Valid @RequestBody ReactGroupInDto reactGroupInDto){
+        ReactGroupOutDto newGroupMember = reactGroupService.createNewGroupMember(reactGroupInDto);
         return new ResponseEntity<>(newGroupMember, HttpStatus.CREATED);
     }
 
@@ -142,9 +158,9 @@ public class ReactGroupController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ReactGroupDto> updateGroupMemberInfo(@PathVariable Long id
-                                                , @Valid @RequestBody ReactGroupDto reactGroupDto) {
-        ReactGroupDto updatedGroupMember = reactGroupService.updateGroupMember(id, reactGroupDto);
+    public ResponseEntity<ReactGroupOutDto> updateGroupMemberInfo(@PathVariable Long id
+                                                , @Valid @RequestBody ReactGroupInDto reactGroupInDto) {
+        ReactGroupOutDto updatedGroupMember = reactGroupService.updateGroupMember(id, reactGroupInDto);
         return new ResponseEntity<>(updatedGroupMember, HttpStatus.OK);
     }
 
@@ -173,10 +189,15 @@ public class ReactGroupController {
     }
 
 
-    @DeleteMapping(path ="/{id}", produces = MediaType.TEXT_PLAIN_VALUE + ";charset=UTF-8")
-    public ResponseEntity<String> deleteGroupMember (@PathVariable Long id) {
-        reactGroupService.deleteGroupMember(id);
-        return new ResponseEntity<>("Group member successfully deleted", HttpStatus.NO_CONTENT);
+//    @DeleteMapping(path ="/{id}", produces = MediaType.TEXT_PLAIN_VALUE + ";charset=UTF-8")
+//    public ResponseEntity<String> deleteGroupMember (@PathVariable Long id) {
+//        reactGroupService.deleteGroupMember(id);
+//        return new ResponseEntity<>("Group member successfully deleted", HttpStatus.NO_CONTENT);
+//    }
+    @PutMapping("/{id}/retire")
+    public ResponseEntity<ReactGroupOutDto> retireGroupMember(@PathVariable Long id) {
+        ReactGroupOutDto retiredMember = reactGroupService.retireGroupMember(id);
+        return new ResponseEntity<>(retiredMember, HttpStatus.OK);
     }
 
     @DeleteMapping(path = "/transport/{id}", produces = MediaType.TEXT_PLAIN_VALUE + ";charset=UTF-8")

--- a/backend/src/main/java/ru/itmo/backend/dto/ReactGroupInDto.java
+++ b/backend/src/main/java/ru/itmo/backend/dto/ReactGroupInDto.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @Data
-public class ReactGroupDto {
+public class ReactGroupInDto {
     private Long id;
 
     @NotEmpty

--- a/backend/src/main/java/ru/itmo/backend/dto/ReactGroupInDto.java
+++ b/backend/src/main/java/ru/itmo/backend/dto/ReactGroupInDto.java
@@ -8,7 +8,7 @@ import javax.validation.constraints.Size;
 
 @Data
 public class ReactGroupInDto {
-    private Long id;
+    //private Long id;
 
     @NotEmpty
     @NotNull

--- a/backend/src/main/java/ru/itmo/backend/dto/ReactGroupOutDto.java
+++ b/backend/src/main/java/ru/itmo/backend/dto/ReactGroupOutDto.java
@@ -3,16 +3,9 @@ package ru.itmo.backend.dto;
 import lombok.Data;
 
 @Data
-public class ReactGroupStatisticDto {
+public class ReactGroupOutDto {
     private Long id;
-
     private String memberName;
-
     private int telegramId;
-
     private boolean inOperation;
-
-    private int criminalsCaught;
-
-    private int criminalsEscaped;
 }

--- a/backend/src/main/java/ru/itmo/backend/mapper/ReactGroupMapper.java
+++ b/backend/src/main/java/ru/itmo/backend/mapper/ReactGroupMapper.java
@@ -1,10 +1,11 @@
 package ru.itmo.backend.mapper;
 
-import ru.itmo.backend.dto.ReactGroupDto;
+import ru.itmo.backend.dto.ReactGroupInDto;
+import ru.itmo.backend.dto.ReactGroupOutDto;
 import ru.itmo.backend.models.ReactGroup;
 
 public class ReactGroupMapper {
-    public static ReactGroup mapToReactGroup(ReactGroupDto groupDto){
+    public static ReactGroup mapToReactGroup(ReactGroupInDto groupDto){
         ReactGroup group = ReactGroup.builder()
                 .id(groupDto.getId())
                 .memberName(groupDto.getMemberName())
@@ -12,11 +13,12 @@ public class ReactGroupMapper {
                 .build();
         return group;
     }
-    public static ReactGroupDto mapToReactGroupDto(ReactGroup group){
-        ReactGroupDto groupDto = new ReactGroupDto();
+    public static ReactGroupOutDto mapToReactGroupOutDto(ReactGroup group){
+        ReactGroupOutDto groupDto = new ReactGroupOutDto();
         groupDto.setId(group.getId());
         groupDto.setMemberName(group.getMemberName());
         groupDto.setTelegramId(group.getTelegramId());
+        groupDto.setInOperation(group.isInOperation());
         return groupDto;
     }
 }

--- a/backend/src/main/java/ru/itmo/backend/mapper/ReactGroupMapper.java
+++ b/backend/src/main/java/ru/itmo/backend/mapper/ReactGroupMapper.java
@@ -7,7 +7,7 @@ import ru.itmo.backend.models.ReactGroup;
 public class ReactGroupMapper {
     public static ReactGroup mapToReactGroup(ReactGroupInDto groupDto){
         ReactGroup group = ReactGroup.builder()
-                .id(groupDto.getId())
+                //.id(groupDto.getId())
                 .memberName(groupDto.getMemberName())
                 .telegramId(groupDto.getTelegramId())
                 .build();

--- a/backend/src/main/java/ru/itmo/backend/models/ReactGroup.java
+++ b/backend/src/main/java/ru/itmo/backend/models/ReactGroup.java
@@ -25,4 +25,7 @@ public class ReactGroup {
 
     @Column(unique = true)
     private int telegramId;
+
+    @Builder.Default
+    private boolean inOperation = true;
 }

--- a/backend/src/main/java/ru/itmo/backend/repository/ReactGroupRepository.java
+++ b/backend/src/main/java/ru/itmo/backend/repository/ReactGroupRepository.java
@@ -3,9 +3,11 @@ package ru.itmo.backend.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import ru.itmo.backend.models.ReactGroup;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReactGroupRepository extends JpaRepository<ReactGroup, Long> {
     Optional<ReactGroup> findById(Long id);
     ReactGroup findByTelegramId(int telegramId);
+    List<ReactGroup> findAllByInOperationIsTrue();
 }

--- a/backend/src/main/java/ru/itmo/backend/service/ReactGroupService.java
+++ b/backend/src/main/java/ru/itmo/backend/service/ReactGroupService.java
@@ -1,17 +1,20 @@
 package ru.itmo.backend.service;
 
-import ru.itmo.backend.dto.ReactGroupDto;
+import ru.itmo.backend.dto.ReactGroupInDto;
+import ru.itmo.backend.dto.ReactGroupOutDto;
 import ru.itmo.backend.models.Criminal;
 import ru.itmo.backend.models.ReactGroup;
 
 import java.util.List;
 
 public interface ReactGroupService {
-    ReactGroupDto createNewGroupMember(ReactGroupDto reactGroupDto);
+    ReactGroupOutDto createNewGroupMember(ReactGroupInDto reactGroupInDto);
     ReactGroup findGroupMemberById(Long id);
     Criminal findCriminalById(Long id);
     List<ReactGroup> getAllMembers();
-    void deleteGroupMember(Long id);
-    ReactGroupDto updateGroupMember(Long id, ReactGroupDto reactGroupDto);
+    List<ReactGroup> getAllWorkingMembers();
+    //void deleteGroupMember(Long id);
+    ReactGroupOutDto retireGroupMember(Long id);
+    ReactGroupOutDto updateGroupMember(Long id, ReactGroupInDto reactGroupInDto);
     void appointGroupToCriminal(Long id, List<Long> group);
 }

--- a/backend/src/main/java/ru/itmo/backend/service/StatisticService.java
+++ b/backend/src/main/java/ru/itmo/backend/service/StatisticService.java
@@ -1,5 +1,6 @@
 package ru.itmo.backend.service;
 
+import ru.itmo.backend.dto.ReactGroupStatisticDto;
 import ru.itmo.backend.dto.UserOutDto;
 import ru.itmo.backend.dto.UserStatisticInfo;
 import ru.itmo.backend.models.Criminal;
@@ -28,4 +29,5 @@ public interface StatisticService {
     void enteredDepressant(UserEntity technic, int amount);
 
     UserStatisticInfo getUserStatistic(Long id);
+    ReactGroupStatisticDto getGroupMemberStatistic(Long id);
 }

--- a/backend/src/main/java/ru/itmo/backend/service/impl/GroupResourceImpl.java
+++ b/backend/src/main/java/ru/itmo/backend/service/impl/GroupResourceImpl.java
@@ -1,6 +1,7 @@
 package ru.itmo.backend.service.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import ru.itmo.backend.dto.ResourceDto;
 import ru.itmo.backend.dto.TransportDto;
@@ -49,7 +50,7 @@ public class GroupResourceImpl implements GroupResourceService {
 
     @Override
     public List<GroupResource> getAllResources() {
-        return groupResourceRepository.findAll();
+        return groupResourceRepository.findAll(Sort.by(Sort.Direction.DESC, "id"));
     }
 
     @Override
@@ -145,7 +146,7 @@ public class GroupResourceImpl implements GroupResourceService {
 
     @Override
     public List<Transport> getAllTransport() {
-        return transportRepository.findAll();
+        return transportRepository.findAll(Sort.by(Sort.Direction.ASC, "id"));
     }
 
     @Override

--- a/backend/src/main/java/ru/itmo/backend/service/impl/StatisticServiceImpl.java
+++ b/backend/src/main/java/ru/itmo/backend/service/impl/StatisticServiceImpl.java
@@ -265,4 +265,19 @@ public class StatisticServiceImpl implements StatisticService {
         }
         return userStatisticInfo;
     }
+
+    @Override
+    public ReactGroupStatisticDto getGroupMemberStatistic(Long id) {
+        ReactGroupStatisticDto reactGroupStatisticDto = new ReactGroupStatisticDto();
+        ReactGroup reactGroup = reactGroupRepository.findById(id)
+                                        .orElseThrow(()-> new NotFoundException("Group member not found: "+id));
+        ReactGroupStatistic reactGroupStatistic = reactGroupStatisticRepository.findByMember(reactGroup);
+        reactGroupStatisticDto.setId(reactGroup.getId());
+        reactGroupStatisticDto.setMemberName(reactGroup.getMemberName());
+        reactGroupStatisticDto.setTelegramId(reactGroup.getTelegramId());
+        reactGroupStatisticDto.setInOperation(reactGroup.isInOperation());
+        reactGroupStatisticDto.setCriminalsCaught(reactGroupStatistic.getCriminalsCaught());
+        reactGroupStatisticDto.setCriminalsEscaped(reactGroupStatistic.getCriminalsEscaped());
+        return reactGroupStatisticDto;
+    }
 }

--- a/backend/src/test/java/ru/itmo/backend/service/ReactGroupServiceTests.java
+++ b/backend/src/test/java/ru/itmo/backend/service/ReactGroupServiceTests.java
@@ -8,7 +8,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import ru.itmo.backend.dto.ReactGroupDto;
+import org.springframework.data.domain.Sort;
+import ru.itmo.backend.dto.ReactGroupInDto;
+import ru.itmo.backend.dto.ReactGroupOutDto;
 import ru.itmo.backend.models.CrimeCard;
 import ru.itmo.backend.models.Criminal;
 import ru.itmo.backend.models.CriminalStatus;
@@ -70,14 +72,14 @@ public class ReactGroupServiceTests {
 
     @Test
     public void ReactGroupService_CreateNewGroupMember_ReturnReactGroupDto(){
-        ReactGroupDto memberToCreate = new ReactGroupDto();
+        ReactGroupInDto memberToCreate = new ReactGroupInDto();
         memberToCreate.setMemberName("Jack Black");
         memberToCreate.setTelegramId(47692);
 
         when(reactGroupRepository.save(Mockito.any(ReactGroup.class))).thenReturn(member1);
         doNothing().when(statisticService).createNewStatisticRecordReactGroup(member1.getTelegramId());
 
-        ReactGroupDto returnValue = reactGroupService.createNewGroupMember(memberToCreate);
+        ReactGroupOutDto returnValue = reactGroupService.createNewGroupMember(memberToCreate);
 
         Assertions.assertNotNull(returnValue);
         Assertions.assertEquals(memberToCreate.getMemberName(),returnValue.getMemberName());
@@ -96,33 +98,33 @@ public class ReactGroupServiceTests {
     @Test
     public void ReactGroupService_GetAllMembers_ReturnListOfReactGroup(){
         List<ReactGroup> reactGroups = Arrays.asList(member1, member2, member3);
-        when(reactGroupRepository.findAll()).thenReturn(reactGroups);
+        when(reactGroupRepository.findAll(Sort.by(Sort.Direction.DESC, "inOperation"))).thenReturn(reactGroups);
         List<ReactGroup> returnValue = reactGroupService.getAllMembers();
 
         Assertions.assertNotNull(returnValue);
         Assertions.assertEquals(reactGroups.size(), returnValue.size());
     }
 
-    @Test
-    public void ReactGroupService_DeleteMember_ReturnVoid(){
-        Long memberId = 2L;
-        when(reactGroupRepository.findById(memberId)).thenReturn(Optional.ofNullable(member2));
-        doNothing().when(reactGroupRepository).delete(member2);
-        Assertions.assertAll(()->{
-            reactGroupService.deleteGroupMember(memberId);
-        });
-
-    }
+//    @Test
+//    public void ReactGroupService_DeleteMember_ReturnVoid(){
+//        Long memberId = 2L;
+//        when(reactGroupRepository.findById(memberId)).thenReturn(Optional.ofNullable(member2));
+//        doNothing().when(reactGroupRepository).delete(member2);
+//        Assertions.assertAll(()->{
+//            reactGroupService.deleteGroupMember(memberId);
+//        });
+//
+//    }
 
     @Test
     public void ReactGroupService_UpdateGroupMember_ReturnReactGroupDto(){
-        ReactGroupDto memberToUpdate = new ReactGroupDto();
+        ReactGroupInDto memberToUpdate = new ReactGroupInDto();
         memberToUpdate.setMemberName("Sam Fisher");
         memberToUpdate.setTelegramId(99999);
         Long memberId = 3L;
         when(reactGroupRepository.findById(memberId)).thenReturn(Optional.ofNullable(member3));
         when(reactGroupRepository.save(member3)).thenReturn(member3);
-        ReactGroupDto returnValue = reactGroupService.updateGroupMember(memberId, memberToUpdate);
+        ReactGroupOutDto returnValue = reactGroupService.updateGroupMember(memberId, memberToUpdate);
 
         Assertions.assertNotNull(returnValue);
         Assertions.assertEquals(memberToUpdate.getMemberName(), member3.getMemberName());


### PR DESCRIPTION
- Удален (закомментирован) метод DELETE для ReactGroup;
- Вместо этого добавлен метод Retire, который устанавливает поле inOperation в false;
- Добавлена возможность получить статистику по каждому из участников группы захвата;
- Метод getAllGroups() теперь возвращает список участников в отсортированном порядке по полю inOperation;
- Добавлен метод getAllWorkingGroup(), который возвращает список участников, у которых поле inOperation равное true
- При выводе всего транспорта и всех ресурсов добавлена сортировка по id по возрастанию